### PR TITLE
chore(quality): enable Biome review and editor checks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[typescript][json][jsonc]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.biome": "explicit",
+      "source.organizeImports.biome": "explicit"
+    },
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Applies to the entire repository. There are no nested instruction files.
 
 - `Proxy/Clash/`: Mihomo configuration templates. Preserve YAML anchors, policy/rule ordering, endpoints and credential-like template fields unless the task targets them.
 - `Proxy/Rules/`: tracked, generated `.mrs` binaries. Their local `*.txt` inputs are ignored by `.gitignore`.
-- `Tools/`: `linux.sh` (Debian/Ubuntu Bash 3.2 system maintenance), `mrs.sh` (Bash 3.2 rule conversion using `mihomo`) and `smartcore.sh` (OpenWrt/BusyBox `ash` Smart-core manager).
+- `Tools/`: `linux.sh` (Debian/Ubuntu system maintenance), `mrs.sh` (rule conversion using `mihomo`) and `smartcore.sh` (OpenWrt/BusyBox `ash` Smart-core manager).
 - `TeleBox_Custom_Plugins/`: standalone TeleBox TypeScript plugins using host-provided aliases and packages; this repository has no TeleBox build or test harness.
 - `zshrc/`, `Brewfile`: Linux/macOS shell and workstation setup.
 - `icon/`: binary image assets plus `icon/icon.json`.
@@ -23,15 +23,18 @@ Applies to the entire repository. There are no nested instruction files.
 
 ## Toolchain and commands
 
-- Use the `packageManager` version in `package.json` (`pnpm@11.14.0`). There is no Node version file; the current dependency graph requires Node `>=22.22.1`.
-- `pnpm-workspace.yaml` intentionally sets `minimumReleaseAge: 0`; do not change this policy without Theo's explicit authorization.
+- Read the package manager and its exact version from `package.json#packageManager`; read declared dependency and CLI ranges from `package.json`, and exact resolutions plus package-engine constraints from `pnpm-lock.yaml`. There is no separate Node runtime pin.
+- Read tool metadata from its owning configuration, such as `biome.json`, instead of recording version snapshots here.
+- Treat the dependency release-age policy in `pnpm-workspace.yaml` as intentional; do not change it without Theo's explicit authorization.
 - Install reproducibly: `pnpm install --frozen-lockfile`
-- Check supported files: `pnpm run format:check`
+- Run the canonical formatter, linter and assist check: `pnpm run format:check`
 - Apply Biome formatting/organize-imports only when intended: `pnpm run format`
 - Regenerate rule sets only when intended: `pnpm run mrs`
 - Always check patch whitespace: `git diff --check`
 
-Biome formats supported JSON/TypeScript files. It excludes `pnpm-lock.yaml`, Clash YAML, `.mrs` files and images; shell and Markdown are not validated by Biome. The linter is disabled. Do not add Prettier. `lint-staged` is configured but no Git hook invokes it automatically. There is no repository build, unit-test or TypeScript typecheck command.
+Biome checks supported JSON/TypeScript files with its formatter, recommended linter and organize-imports assist. It excludes `pnpm-lock.yaml`, Clash YAML, `.mrs` files and images; shell and Markdown are not validated by Biome. TypeScript diagnostic-suppression comments are rejected: reproduce the diagnostic and make a minimal type-safe root-cause fix instead of adding another suppression, `any`, double assertions or narrower checks. Do not add Prettier. `lint-staged` is configured but no Git hook invokes it automatically. There is no repository build, unit-test or TypeScript typecheck command.
+
+The VS Code workspace uses Biome only for the tracked TypeScript, JSON and JSONC languages. Keep shell, Zsh, YAML, Markdown and other unsupported files on their existing tools.
 
 ## Editing constraints
 
@@ -48,7 +51,7 @@ Biome formats supported JSON/TypeScript files. It excludes `pnpm-lock.yaml`, Cla
 
 ### Scripts and plugins
 
-- `Tools/linux.sh` and `Tools/mrs.sh` may use Bash 3.2 features; keep `Tools/smartcore.sh` POSIX/BusyBox `ash` compatible.
+- Keep `Tools/linux.sh` and `Tools/mrs.sh` compatible with Bash 3.2, the minimum declared in their headers; do not introduce newer Bash features. Keep `Tools/smartcore.sh` POSIX/BusyBox `ash` compatible.
 - Do not run interactive/update modes of system scripts as tests: they can install packages, alter firewalls/shells or replace and restart the OpenClash core.
 - TeleBox imports such as `@utils/*` and `teleproto` are supplied by the host project. Do not invent local dependencies or claim local typechecking coverage.
 - Keep asset filenames and `icon/icon.json` URLs aligned. Avoid changing public download URLs or proxy/sponsor endpoints incidentally.

--- a/TeleBox_Custom_Plugins/dme.ts
+++ b/TeleBox_Custom_Plugins/dme.ts
@@ -15,7 +15,7 @@ import { getGlobalClient } from '@utils/globalClient'
 import { Plugin } from '@utils/pluginBase'
 import * as fs from 'fs'
 import * as path from 'path'
-import { Api, TelegramClient } from 'teleproto'
+import { Api, type TelegramClient } from 'teleproto'
 import { CustomFile } from 'teleproto/client/uploads'
 
 // 常量配置
@@ -34,20 +34,6 @@ const CONFIG = {
     NETWORK_ERROR: 5000
   }
 } as const
-
-// 工具函数
-const htmlEscape = (text: string): string =>
-  text.replace(
-    /[&<>"']/g,
-    (m) =>
-      ({
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#x27;'
-      })[m] || m
-  )
 
 const prefixes = ['.']
 const mainPrefix = prefixes[0]
@@ -382,8 +368,8 @@ const dme = async (msg: Api.Message) => {
     }
     // ================== 场景2：数量模式 (.dme 10) ==================
     else {
-      let count = parseInt(firstArg)
-      if (isNaN(count) || count <= 0) {
+      const count = parseInt(firstArg, 10)
+      if (Number.isNaN(count) || count <= 0) {
         // 如果没有回复且参数不对，默认可能是误触或需要帮助，但因为删除了命令，这里只打印日志
         console.log(`[DME] 参数无效`)
         return

--- a/TeleBox_Custom_Plugins/t.ts
+++ b/TeleBox_Custom_Plugins/t.ts
@@ -1,15 +1,11 @@
 import { createDirectoryInAssets } from '@utils/pathHelpers'
 import { Plugin } from '@utils/pluginBase'
-import { getPrefixes } from '@utils/pluginManager'
 import axios from 'axios'
 import { exec } from 'child_process'
 import * as fs from 'fs/promises'
 import path from 'path'
 import { Api } from 'teleproto'
 import { promisify } from 'util'
-
-const prefixes = getPrefixes()
-const mainPrefix = prefixes[0]
 
 const execPromise = promisify(exec)
 const EDGE_TTS = '/root/.local/bin/edge-tts' // ✅ 强制绝对路径

--- a/TeleBox_Custom_Plugins/yvlu.ts
+++ b/TeleBox_Custom_Plugins/yvlu.ts
@@ -2,14 +2,13 @@
 //@ts-nocheck
 
 import { getGlobalClient } from '@utils/globalClient'
-import { createDirectoryInAssets, createDirectoryInTemp } from '@utils/pathHelpers'
+import { createDirectoryInAssets } from '@utils/pathHelpers'
 import { Plugin } from '@utils/pluginBase'
 import { getPrefixes } from '@utils/pluginManager'
 import { reviveEntities } from '@utils/tlRevive'
 import axios from 'axios'
 import { execFile } from 'child_process'
 import * as fs from 'fs'
-import _ from 'lodash'
 import * as path from 'path'
 import { Api } from 'teleproto'
 import { CustomFile } from 'teleproto/client/uploads.js'
@@ -51,7 +50,7 @@ async function checkTgsDependencies(): Promise<{
 }> {
   try {
     await execFileAsync('python3', ['-c', 'from rlottie_python import LottieAnimation'])
-  } catch (e) {
+  } catch {
     return {
       ok: false,
       message: '缺少 rlottie-python 依赖，请运行: pip3 install rlottie-python Pillow --break-system-packages'
@@ -59,7 +58,7 @@ async function checkTgsDependencies(): Promise<{
   }
   try {
     await execFileAsync('ffmpeg', ['-version'])
-  } catch (e) {
+  } catch {
     return {
       ok: false,
       message: '缺少 ffmpeg，请安装: apt-get install -y ffmpeg'
@@ -72,7 +71,7 @@ async function checkTgsDependencies(): Promise<{
 async function convertTgsToWebm(tgsBuffer: Buffer): Promise<Buffer> {
   const os = await import('os')
   const tmpDir = os.tmpdir()
-  const uniqueId = Date.now().toString() + '_' + Math.random().toString(36).slice(2)
+  const uniqueId = `${Date.now().toString()}_${Math.random().toString(36).slice(2)}`
   const tgsPath = path.join(tmpDir, `sticker_${uniqueId}.tgs`)
   const gifPath = path.join(tmpDir, `sticker_${uniqueId}.gif`)
   const webmPath = path.join(tmpDir, `sticker_${uniqueId}.webm`)
@@ -96,28 +95,14 @@ anim.save_animation(sys.argv[2])
   } finally {
     try {
       fs.unlinkSync(tgsPath)
-    } catch (e) {}
+    } catch {}
     try {
       fs.unlinkSync(gifPath)
-    } catch (e) {}
+    } catch {}
     try {
       fs.unlinkSync(webmPath)
-    } catch (e) {}
+    } catch {}
   }
-}
-
-// 检测是否为动态 WebP
-function isAnimatedWebP(buffer: Buffer): boolean {
-  if (!buffer || buffer.length < 12) return false
-  if (buffer.toString('ascii', 0, 4) !== 'RIFF' || buffer.toString('ascii', 8, 12) !== 'WEBP') {
-    return false
-  }
-  for (let i = 12; i < buffer.length - 4; i++) {
-    if (buffer.toString('ascii', i, i + 4) === 'ANIM') {
-      return true
-    }
-  }
-  return false
 }
 
 // 读取WebP图片尺寸
@@ -144,7 +129,7 @@ function getWebPDimensions(imageBuffer: any): { width: number; height: number } 
       return { width, height }
     }
     return { width: 512, height: 768 }
-  } catch (error) {
+  } catch {
     return { width: 512, height: 768 }
   }
 }
@@ -164,7 +149,7 @@ const resolveForwardSenderFromHeader = async (forwardHeader: Api.MessageFwdHeade
     try {
       const entity = await client?.getEntity(peer as any)
       if (entity) return entity
-    } catch (error) {}
+    } catch {}
   }
   const displayName = forwardHeader.fromName || forwardHeader.postAuthor || ''
   if (displayName) {
@@ -281,7 +266,7 @@ class YvluPlugin extends Plugin {
   async generateQuote(quoteData: any): Promise<{ buffer: Buffer; ext: string }> {
     try {
       let url = this.config?.apiUrl
-      if (!url || !url.trim()) url = DEFAULT_API_URL
+      if (!url?.trim()) url = DEFAULT_API_URL
 
       const response = await axios({
         method: 'post',
@@ -335,12 +320,12 @@ class YvluPlugin extends Plugin {
       // 4. 解析参数 (Quote)
       if (!args[1] || /^\d+$/.test(args[1])) {
         // yvlu 或 yvlu 3
-        count = parseInt(args[1]) || 1
+        count = parseInt(args[1], 10) || 1
         valid = true
       } else if (args[1] === 'r') {
         // yvlu r 3
         r = true
-        count = parseInt(args[2]) || 1
+        count = parseInt(args[2], 10) || 1
         valid = true
       } else {
         // yvlu 这里是自定义文字
@@ -350,7 +335,7 @@ class YvluPlugin extends Plugin {
       }
 
       if (valid) {
-        let replied = await msg.getReplyMessage()
+        const replied = await msg.getReplyMessage()
         if (!replied) {
           await msg.edit({ text: '请回复一条消息' })
           return
@@ -385,13 +370,13 @@ class YvluPlugin extends Plugin {
               try {
                 const peerId = (message as any).peerId || (message as any).fromId
                 if (peerId) sender = await client.getEntity(peerId)
-              } catch (e) {}
+              } catch {}
             }
             if (message.fwdFrom) {
-              let forwardedSender = undefined
+              let forwardedSender: unknown
               try {
                 forwardedSender = await message.forward?.getSender()
-              } catch (e) {}
+              } catch {}
               if (!forwardedSender) forwardedSender = await resolveForwardSenderFromHeader(message.fwdFrom, client)
               if (forwardedSender) sender = forwardedSender
             }
@@ -412,7 +397,7 @@ class YvluPlugin extends Plugin {
             const shouldShowAvatar = currentUserIdentifier !== previousUserIdentifier
             previousUserIdentifier = currentUserIdentifier
 
-            let photo: { url: string } | undefined = undefined
+            let photo: { url: string } | undefined
             if (shouldShowAvatar) {
               try {
                 const buffer = await client.downloadProfilePhoto(sender as any, { isBig: false })
@@ -421,12 +406,12 @@ class YvluPlugin extends Plugin {
                     url: `data:image/jpeg;base64,${buffer.toString('base64')}`
                   }
                 }
-              } catch (e) {}
+              } catch {}
             }
 
             // [自定义文字逻辑]
             if (i === 0) {
-              let replyTo = (trigger || msg)?.replyTo
+              const replyTo = (trigger || msg)?.replyTo
               if (customText) {
                 // 如果有自定义文字，替换当前消息内容
                 message.message = customText
@@ -463,11 +448,11 @@ class YvluPlugin extends Plugin {
                     }
                   }
                 }
-              } catch (e) {}
+              } catch {}
             }
 
             // [媒体处理逻辑 - 集成 TGS 支持]
-            let media: { url: string } | undefined = undefined
+            let media: { url: string } | undefined
             try {
               if (message.media) {
                 const isSticker = message.media instanceof Api.MessageMediaDocument && (message.media as Api.MessageMediaDocument).document && ((message.media as Api.MessageMediaDocument).document as any).attributes?.some((a: any) => a instanceof Api.DocumentAttributeSticker)
@@ -514,7 +499,7 @@ class YvluPlugin extends Plugin {
 
             items.push({
               from: {
-                id: userId ? parseInt(userId) : hashCode(sender.name),
+                id: userId ? parseInt(userId, 10) : hashCode(sender.name),
                 name: shouldShowAvatar ? name : '',
                 first_name: shouldShowAvatar ? firstName : undefined,
                 last_name: shouldShowAvatar ? lastName : undefined,
@@ -575,7 +560,7 @@ class YvluPlugin extends Plugin {
               } finally {
                 try {
                   fs.unlinkSync(webmPath)
-                } catch (e) {}
+                } catch {}
               }
             } else {
               const file = new CustomFile(`sticker.${imageExt}`, imageBuffer.length, '', imageBuffer)
@@ -654,8 +639,8 @@ class YvluPlugin extends Plugin {
       await msg.edit({ text: '✅ API已重置为默认' })
     } else {
       let url = sub
-      if (!url.startsWith('http')) url = 'https://' + url
-      if (!url.includes('/generate')) url = url.replace(/\/$/, '') + '/generate.webp'
+      if (!url.startsWith('http')) url = `https://${url}`
+      if (!url.includes('/generate')) url = `${url.replace(/\/$/, '')}/generate.webp`
       this.config!.apiUrl = url
       await this.saveConfig()
       await msg.edit({
@@ -676,7 +661,7 @@ class YvluPlugin extends Plugin {
       }
 
       const replied = await msg.getReplyMessage()
-      if (!replied || !replied.media) {
+      if (!replied?.media) {
         await msg.edit({ text: '❌ 请回复一张贴纸或图片' })
         return
       }
@@ -688,7 +673,7 @@ class YvluPlugin extends Plugin {
 
       if (replied.media instanceof Api.MessageMediaDocument) {
         const doc = replied.media.document as any
-        if (doc && doc.attributes) {
+        if (doc?.attributes) {
           isSticker = doc.attributes.some((a: any) => a instanceof Api.DocumentAttributeSticker)
         }
         if (isSticker && doc.id && doc.accessHash) {

--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,13 @@
     }
   },
   "linter": {
-    "enabled": false
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "suspicious": {
+        "noTsIgnore": "error"
+      }
+    }
   },
   "assist": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- stabilize `AGENTS.md` so tool versions come from repository metadata and document the canonical quality workflow
- enable Biome's recommended linter, keep formatting and organize-imports active, and reject TypeScript diagnostic-suppression comments
- add scoped VS Code settings for TypeScript, JSON, and JSONC only
- apply mechanically safe Biome fixes to the three TeleBox plugins without changing host API assumptions

## Reviewed baseline

The canonical check succeeds with the intentionally retained TeleBox baseline:

- 55 `lint/suspicious/noExplicitAny` warnings
- 9 `lint/style/noNonNullAssertion` warnings
- 12 `lint/style/useNodejsImportProtocol` infos
- 1 `lint/complexity/useLiteralKeys` info

These remain because this repository does not provide the TeleBox host types, loader, or test harness needed to prove broader changes safe. The existing `TeleBox_Custom_Plugins/yvlu.ts:2` `@ts-nocheck` directive is explicitly outside this rollout's authorized scope and remains unchanged.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run format:check`
- pinned Biome/schema assertions
- VS Code workspace-setting assertions
- target suppression literal scan: 0 matches
- AGENTS CJK scan: 0 matches
- temporary probe scan: 0 matches
- `git diff --check`

There is no repository-local TeleBox typecheck or test harness, and the only tracked GitHub Actions workflow amends pushed `main` commits rather than validating pull requests.

## Rollback

Revert the resulting squash commit to restore the previous Biome, editor, instruction, and TeleBox plugin state as one unit.